### PR TITLE
Removes Net::IP as dependency, use Net::IP::XS only.

### DIFF
--- a/lib/Zonemaster/Engine/Net/IP.pm
+++ b/lib/Zonemaster/Engine/Net/IP.pm
@@ -4,21 +4,7 @@ use version; our $VERSION = version->declare("v0.0.6");
 
 use strict;
 use warnings;
-
-my $p_class = eval {
-    require Net::IP::XS;
-    return q{Net::IP::XS};
-} || eval {
-    require Net::IP;
-    return q{Net::IP};
-};
-
-if ( $p_class ) {
-    $p_class->import;
-}
-else {
-    die "Both Net::IP and Net::IP::XS missing?\n";
-}
+use Net::IP::XS;
 
 sub new {
     my ( $class, @args ) = @_;
@@ -70,37 +56,22 @@ sub version {
 }
 
 sub ip_is_ipv4 {
-    if ( $p_class eq 'Net::IP::XS' ) {
-        return Net::IP::XS::ip_is_ipv4( @_ );
-    }
-    else {
-        return Net::IP::ip_is_ipv4( @_ );
-    }
+    return Net::IP::XS::ip_is_ipv4( @_ );
 }
 
 sub ip_is_ipv6 {
-    if ( $p_class eq 'Net::IP::XS' ) {
-        return Net::IP::XS::ip_is_ipv6( @_ );
-    }
-    else {
-        return Net::IP::ip_is_ipv6( @_ );
-    }
+    return Net::IP::XS::ip_is_ipv6( @_ );
 }
 
 sub Error {
-    if ( $p_class eq 'Net::IP::XS' ) {
-        return Net::IP::XS::Error();
-    }
-    else {
-        return Net::IP::Error();
-    }
+    return Net::IP::XS::Error();
 }
 
 1;
 
 =head1 NAME
 
-Zonemaster::Engine::Net::IP - Net::IP/Net::IP::XS Wrapper (STILL EXPERIMENTAL)
+Zonemaster::Engine::Net::IP - Net::IP::XS Wrapper
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
## Purpose

Updates lib/Zonemaster/Engine/Net/IP.pm to not be dependent on Net::IP.

